### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,113 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-11-25
+
+### ⚠️ BREAKING CHANGES
+
+This release includes a major refactor of the DownloadManager API to provide a cleaner, more intuitive interface, plus significant internal improvements.
+
+**API Changes:**
+
+- `add_to_queue()` → `add()`
+- `queue.join()` → `wait_until_complete()`
+- `start_workers()` → `open()` or use context manager
+- `stop_workers()` → `close()` or use context manager
+- `shutdown()` → `cancel_all()`
+- `request_shutdown()` removed (use `cancel_all()`)
+- `max_workers` parameter → `max_concurrent` (in DownloadManager, Settings, and CLI)
+- `worker=` parameter → `worker_factory=` (for dependency injection)
+
+**Migration Example:**
+
+```python
+# Before (v0.1.0)
+async with DownloadManager(max_workers=5, worker=my_worker) as manager:
+    await manager.add_to_queue(files)
+    await manager.queue.join()
+    await manager.shutdown(wait_for_current=True)
+
+# After (v0.2.0)
+async with DownloadManager(max_concurrent=5, worker_factory=my_factory) as manager:
+    await manager.add(files)
+    await manager.wait_until_complete()
+    await manager.cancel_all(wait_for_current=True)
+```
+
+### Added
+
+- **New DownloadManager API methods:**
+
+  - `add(files)` - Add files to download queue
+  - `wait_until_complete(timeout=None)` - Wait for all downloads to finish
+  - `cancel_all(wait_for_current=False)` - Cancel pending downloads
+  - `open()` / `close()` - Manual lifecycle management
+  - `is_active` property - Check if manager is running
+
+- **WorkerPool extraction (#43):**
+
+  - New `WorkerPool` class for managing worker lifecycle and queue processing
+  - `BaseWorkerPool` ABC defining pool interface
+  - `WorkerPoolFactory` Protocol for type safety
+  - Comprehensive test suite with 15+ tests covering initialization, lifecycle, shutdown, and error handling
+
+- **Worker isolation improvements (#42):**
+
+  - `BaseWorker` ABC for worker interface
+  - `WorkerFactory` Protocol for dependency injection
+  - Per-task worker instances with isolated event emitters to prevent race conditions
+  - Worker factory pattern tests
+
+- **Examples improvements:**
+  - Unique filenames in all examples to prevent overwrites
+  - Naming scheme: `{example_number}-{category}-{size}-{descriptor}.dat`
+  - Real-time progress display with `flush=True`
+
+### Changed
+
+- **Package reorganization (#41):**
+
+  - Restructured `downloads/` package into focused subdirectories:
+    - `downloads/worker/` - Download worker implementations
+    - `downloads/validation/` - Hash validation logic
+    - `downloads/retry/` - Retry handling and error categorization
+  - Improved separation of concerns and extensibility
+
+- **DownloadManager improvements:**
+
+  - Refactored to delegate worker management to `WorkerPool`
+  - Simplified manager test suite
+  - Workers remain active after `wait_until_complete()`, enabling multiple add/wait cycles
+
+- **Documentation:**
+
+  - Updated all documentation to reflect new API
+  - Comprehensive usage examples in DownloadManager docstring
+  - Updated README.md, docs/README.md, and docs/ARCHITECTURE.md
+  - All 5 example files updated with new API
+
+- **Testing:**
+  - Reorganized manager tests by functionality (queue, pool, lifecycle, properties)
+  - Created new `test_lifecycle.py` for integration scenarios
+  - Removed obsolete `test_worker_isolation.py` (functionality moved to WorkerPool tests)
+
+### Removed
+
+- `add_to_queue()` method - replaced by `add()`
+- `start_workers()` method - use `open()` or context manager
+- `stop_workers()` method - use `close()` or context manager
+- `shutdown()` method - replaced by `cancel_all()`
+- `request_shutdown()` method - use `cancel_all()`
+- `worker=` parameter - replaced by `worker_factory=`
+- Backwards compatibility for `max_workers` parameter
+
+### Internal
+
+- Worker instances created per-task instead of shared across all tasks
+- Each worker gets isolated EventEmitter to prevent race conditions
+- WorkerPool handles worker lifecycle, queue processing, and graceful shutdown
+- Improved test coverage with comprehensive worker pool test suite
+
 ## [0.1.0] - 2025-11-21
 
 Initial release. See [README.md](README.md) for full feature list.

--- a/README.md
+++ b/README.md
@@ -65,19 +65,19 @@ rheo download https://example.com/file.zip --hash sha256:abc123...
 rheo download https://example.com/file.zip -o /path/to/dir
 ```
 
-See [CLI Reference](docs/CLI.md) for complete command documentation.
+See [CLI Reference](https://github.com/plutopulp/rheo/blob/main/docs/CLI.md) for complete command documentation.
 
 ## Documentation
 
-- **[Full Documentation](docs/README.md)** - Complete guide with detailed examples
-- **[CLI Reference](docs/CLI.md)** - Command-line interface
-- **[Architecture](docs/ARCHITECTURE.md)** - System design and patterns
-- **[Contributing](CONTRIBUTING.md)** - Development setup and guidelines
-- **[Roadmap](docs/ROADMAP.md)** - What's next
+- **[Full Documentation](https://github.com/plutopulp/rheo/blob/main/docs/README.md)** - Complete guide with detailed examples
+- **[CLI Reference](https://github.com/plutopulp/rheo/blob/main/docs/CLI.md)** - Command-line interface
+- **[Architecture](https://github.com/plutopulp/rheo/blob/main/docs/ARCHITECTURE.md)** - System design and patterns
+- **[Contributing](https://github.com/plutopulp/rheo/blob/main/CONTRIBUTING.md)** - Development setup and guidelines
+- **[Roadmap](https://github.com/plutopulp/rheo/blob/main/docs/ROADMAP.md)** - What's next
 
 ## Examples
 
-Check [`examples/`](examples/) for working code:
+Check [`examples/`](https://github.com/plutopulp/rheo/tree/main/examples) for working code:
 
 - `01_basic_download.py` - Simple single file download
 - `02_multiple_with_priority.py` - Multiple files with priorities
@@ -95,4 +95,4 @@ Check [`examples/`](examples/) for working code:
 
 ## Questions?
 
-Open an issue on [GitHub](https://github.com/plutopulp/rheo) or check the [full documentation](docs/README.md).
+Open an issue on [GitHub](https://github.com/plutopulp/rheo) or check the [full documentation](https://github.com/plutopulp/rheo/blob/main/docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -505,10 +505,10 @@ MIT Licence - see LICENSE file for details.
 
 ## Documentation
 
-- **[CLI Reference](docs/CLI.md)** - Complete command-line interface documentation
-- **[Architecture](docs/ARCHITECTURE.md)** - System design and component overview
-- **[Roadmap](docs/ROADMAP.md)** - Feature roadmap and development phases
-- **[Ideas](docs/IDEAS.md)** - Future ideas and brainstorming
+- **[CLI Reference](CLI.md)** - Complete command-line interface documentation
+- **[Architecture](ARCHITECTURE.md)** - System design and component overview
+- **[Roadmap](ROADMAP.md)** - Feature roadmap and development phases
+- **[Ideas](IDEAS.md)** - Future ideas and brainstorming
 
 ## Questions?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rheopy"
-version = "0.1.0"
+version = "0.2.0"
 description = "Concurrent HTTP download orchestration with async I/O"
 authors = [
     {name = "plutopulp", email = "plutopulped@gmail.com"}


### PR DESCRIPTION
Prepare for v0.2.0 release with changelog, version bump, and PyPI link fixes.

Version:
- Bump version to 0.2.0 in pyproject.toml

Changelog:
- Add comprehensive v0.2.0 entry documenting all changes since v0.1.0
- Breaking changes: Manager API refactor, parameter renames, worker factory
- Added: New methods, WorkerPool, worker isolation, example improvements
- Changed: Package reorganization, documentation updates, test improvements
- Removed: All deprecated methods
- Covers PRs #49, #43, #42, #41, #37

Documentation:
- Fix broken PyPI links in README.md (convert to GitHub absolute URLs)
- Fix incorrect path prefix in docs/README.md
- All documentation and examples links now work on both PyPI and GitHub

Files changed:
- pyproject.toml (version bump)
- CHANGELOG.md (new v0.2.0 entry)
- README.md (6 links fixed for PyPI compatibility)
- docs/README.md (4 links fixed for correct relative paths)