### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-12-01
+
+### ⚠️ BREAKING CHANGES
+
+**API Simplification:**
+
+- `cancel_all()` removed from DownloadManager - use `close(wait_for_current=True/False)` instead
+- `stop()` and `request_shutdown()` removed from WorkerPool public interface
+
+**Migration:**
+
+```python
+# Before (v0.2.0)
+await manager.cancel_all(wait_for_current=True)
+
+# After (v0.3.0)
+await manager.close(wait_for_current=True)
+```
+
+### Changed
+
+- **Simplified shutdown API:**
+
+  - WorkerPool now exposes single `shutdown(wait_for_current)` method
+  - Manager's `close(wait_for_current)` handles both graceful and immediate shutdown
+  - Context manager methods (`__aenter__`/`__aexit__`) delegate to `open()`/`close()`
+  - Clearer control flow with inlined cancellation logic
+
+- **Download ID system:**
+  - Each download has a unique 16-char hex ID from URL + destination
+  - Tracker keyed by download_id instead of URL
+  - Queue deduplication prevents duplicate downloads (same URL+destination)
+  - All events include download_id for correlation
+
+### Fixed
+
+- Example 03 (hash validation): Use `file_config.id` instead of URL for tracker lookup
+- Example 04 (progress tracking): Extract filename from `event.url` (no `filename` attribute)
+
 ## [0.2.0] - 2025-11-25
 
 ### ⚠️ BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Check [`examples/`](https://github.com/plutopulp/rheo/tree/main/examples) for wo
 
 - Python: 3.12+
 - License: MIT
-- Version: 0.1.0
+- Version: 0.3.0
 
 ## Questions?
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -371,7 +371,7 @@ config4 = FileConfig(url="https://example.com/file.zip", destination_subdir="dir
 The system uses an event-based shutdown mechanism for clean termination:
 
 ```text
-1. User calls manager.shutdown(wait_for_current=True/False)
+1. User calls manager.close(wait_for_current=True/False)
 2. Manager delegates to pool.shutdown(wait_for_current)
 3. Pool sets internal _shutdown_event
 4. Worker process_queue loops check event status:

--- a/docs/README.md
+++ b/docs/README.md
@@ -392,7 +392,7 @@ async with DownloadManager(download_dir=Path("./downloads"), max_concurrent=3) a
     await asyncio.sleep(5)
 
     # Gracefully shut down (waits for current downloads to finish)
-    await manager.shutdown(wait_for_current=True)
+    await manager.close(wait_for_current=True)
 ```
 
 **Immediate cancellation** when you need to stop right away:
@@ -406,10 +406,10 @@ async with DownloadManager(download_dir=Path("./downloads")) as manager:
     await asyncio.sleep(2)
 
     # Stop immediately without waiting
-    await manager.shutdown(wait_for_current=False)
+    await manager.close(wait_for_current=False)
 ```
 
-**Note**: The context manager (`async with`) automatically triggers graceful shutdown on exit, so explicit `shutdown()` calls are only needed for early termination.
+**Note**: The context manager (`async with`) automatically triggers immediate shutdown on exit, so explicit `close()` calls are only needed for early termination or graceful shutdown.
 
 ## Security Considerations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rheopy"
-version = "0.2.0"
+version = "0.3.0"
 description = "Concurrent HTTP download orchestration with async I/O"
 authors = [
     {name = "plutopulp", email = "plutopulped@gmail.com"}


### PR DESCRIPTION
Update changelog and docs for v0.3.0 release.

- Add changelog entry for shutdown API simplification and download ID system
- Update docs to use close() instead of shutdown()/cancel_all()
- Bump package version